### PR TITLE
fix: Package build checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,10 @@ Description: Provides a nice set of defaults when working with Hugo and Rmd file
     All of the hardwork is done by {rmarkdown}.
 License: GPL-3
 Imports:
-  rmarkdown,
-  knitr
+    rmarkdown,
+    knitr,
+    stringr,
+    cli
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# hugostyle 1.0.2 _2022-04-22_
+  * fix: R CMD check documentation warning
+  * fix: R CMD check missing dependencies warning
+  * build: Drop dependency on unexported {rmarkdown} functions
+    * defined in package with reference to version that defs were taken from
+
 # hugostyle 1.0.1 _2022-03-16_
   * Feat: Allow hugo snippets to pass through Rmd files
 

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -106,7 +106,7 @@ replace_hugo_snippets = function(lines) {
 #' @param preserve_yaml "TRUE" instead of "FALSE"
 #' @param toc,toc_depth,number_sections See `?rmarkdown::md_document`
 #' @param fig_width,fig_height,fig_retina,dev,df_print,includes See `?rmarkdown::md_document`
-#' @param includes,md_extensions,pandoc_args,ext See `?rmarkdown::md_document`
+#' @param md_extensions,pandoc_args,ext See `?rmarkdown::md_document`
 #'
 #'
 #' @export
@@ -123,14 +123,14 @@ hugo_md = function(variant = "commonmark", preserve_yaml = TRUE,
   args = c(args, pandoc_args)
   post_processor = if (preserve_yaml && variant != "markdown") {
     function(metadata, input_file, output_file, clean, verbose) {
-      input_lines = rmarkdown:::read_utf8(input_file)
-      partitioned = rmarkdown:::partition_yaml_front_matter(input_lines)
+      input_lines = read_utf8(input_file)
+      partitioned = partition_yaml_front_matter(input_lines)
       if (!is.null(partitioned$front_matter)) {
-        output_lines = c(partitioned$front_matter, "", rmarkdown:::read_utf8(output_file))
+        output_lines = c(partitioned$front_matter, "", read_utf8(output_file))
         output_lines = replace_hugo_snippets(output_lines)
         output_lines = add_base_url(output_lines)
         check_alt(output_lines)
-        rmarkdown:::write_utf8(output_lines, output_file)
+        write_utf8(output_lines, output_file)
       }
       output_file
     }

--- a/R/rmarkdown.R
+++ b/R/rmarkdown.R
@@ -1,0 +1,64 @@
+# definitions for the unexported rmarkdown functions used within the package
+# definitions match rmarkdown (2.13)
+
+# see rmarkdown:::partition_yaml_front_matter
+partition_yaml_front_matter = function(input_lines) {
+  validate_front_matter <- function(delimiters) {
+    if (
+      length(delimiters) >= 2 &&
+      (delimiters[2] - delimiters[1] > 1) &&
+      grepl("^---\\s*$", input_lines[delimiters[1]])
+    ) {
+      if (delimiters[1] == 1) {
+        TRUE
+      }
+      else {
+        all(grepl(
+          "^\\s*(<!-- rnb-\\w*-(begin|end) -->)?\\s*$",
+          input_lines[1:delimiters[1] - 1]
+        ))
+      }
+    }
+    else {
+      FALSE
+    }
+  }
+  delimiters <- grep("^(---|\\.\\.\\.)\\s*$", input_lines)
+  if (validate_front_matter(delimiters)) {
+    front_matter <- input_lines[(delimiters[1]):(delimiters[2])]
+    input_body <- c()
+    if (delimiters[1] > 1) {
+      input_body <- c(
+        input_body,
+        input_lines[1:delimiters[1] - 1]
+      )
+    }
+
+    if (delimiters[2] < length(input_lines)) {
+      input_body <- c(input_body, input_lines[-(1:delimiters[2])])
+    }
+    list(front_matter = front_matter, body = input_body)
+  }
+  else {
+    list(front_matter = NULL, body = input_lines)
+  }
+}
+
+# see rmarkdown:::read_utf8
+read_utf8 = function(file) {
+  if (inherits(file, "connection")) {
+    con <- file
+  }
+  else {
+    con <- base::file(file, encoding = "UTF-8")
+    on.exit(close(con), add = TRUE)
+  }
+  enc2utf8(readLines(con, warn = FALSE))
+}
+
+# see rmarkdown:::write_utf8
+write_utf8 = function(text, con, ...) {
+  opts <- options(encoding = "native.enc")
+  on.exit(options(opts), add = TRUE)
+  writeLines(enc2utf8(text), con, ..., useBytes = TRUE)
+}

--- a/man/hugo_md.Rd
+++ b/man/hugo_md.Rd
@@ -30,7 +30,7 @@ hugo_md(
 
 \item{fig_width, fig_height, fig_retina, dev, df_print, includes}{See `?rmarkdown::md_document`}
 
-\item{includes, md_extensions, pandoc_args, ext}{See `?rmarkdown::md_document`}
+\item{md_extensions, pandoc_args, ext}{See `?rmarkdown::md_document`}
 }
 \description{
 This format generates a standard markdown file.


### PR DESCRIPTION
* fix: R CMD check documentation warning (duplicate param)
* fix: R CMD check missing dependencies warning (missing cli and stringr)
* build: Drop dependency on unexported {rmarkdown} functions
    * defined in package with reference to version that defs were taken from
