### PR TITLE
test: render hugo_md different pandoc versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: hugostyle
 Title: Default Style for Hugo Sites
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: 
     person("Colin", "Gillespie", , "csgillespie@gmail.com", role = c("aut", "cre"))
 Maintainer: Colin Gillespie <csgillespie@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,10 @@ Description: Provides a nice set of defaults when working with Hugo and Rmd file
     All of the hardwork is done by {rmarkdown}.
 License: GPL-3
 Imports:
-  rmarkdown,
-  knitr
+    rmarkdown,
+    knitr,
+    stringr,
+    cli
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,19 +1,20 @@
-Package: hugostyle
 Type: Package
+Package: hugostyle
 Title: Default Style for Hugo Sites
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
-    c(person(given = "Colin",
-             family = "Gillespie",
-             role = c("aut", "cre"),
-             email = "csgillespie@gmail.com"))
+    person("Colin", "Gillespie", , "csgillespie@gmail.com", role = c("aut", "cre"))
 Maintainer: Colin Gillespie <csgillespie@gmail.com>
-Description: Provides a nice set of defaults when working with Hugo and Rmd files.
-    All of the hardwork is done by {rmarkdown}.
+Description: Provides a nice set of defaults when working with Hugo and
+    Rmd files.  All of the hardwork is done by {rmarkdown}.
 License: GPL-3
 Imports:
-  rmarkdown,
-  knitr
+    knitr,
+    rmarkdown
+Suggests: 
+    testthat (>= 3.0.0),
+    withr
+Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# hugostyle 1.0.2 _2022-04-22_
+  * test: render rmd against both system and rstudio pandoc versions
+
 # hugostyle 1.0.1 _2022-03-16_
   * Feat: Allow hugo snippets to pass through Rmd files
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# hugostyle 1.0.2 _2022-04-22_
+  * fix: R CMD check documentation warning
+  * fix: R CMD check missing dependencies warning
+  * build: Drop dependency on unexported {rmarkdown} functions
+    * defined in package with reference to version that defs were taken from
+
 # hugostyle 1.0.1 _2022-03-16_
   * Feat: Allow hugo snippets to pass through Rmd files
 

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -106,7 +106,7 @@ replace_hugo_snippets = function(lines) {
 #' @param preserve_yaml "TRUE" instead of "FALSE"
 #' @param toc,toc_depth,number_sections See `?rmarkdown::md_document`
 #' @param fig_width,fig_height,fig_retina,dev,df_print,includes See `?rmarkdown::md_document`
-#' @param includes,md_extensions,pandoc_args,ext See `?rmarkdown::md_document`
+#' @param md_extensions,pandoc_args,ext See `?rmarkdown::md_document`
 #'
 #'
 #' @export
@@ -123,14 +123,14 @@ hugo_md = function(variant = "commonmark", preserve_yaml = TRUE,
   args = c(args, pandoc_args)
   post_processor = if (preserve_yaml && variant != "markdown") {
     function(metadata, input_file, output_file, clean, verbose) {
-      input_lines = rmarkdown:::read_utf8(input_file)
-      partitioned = rmarkdown:::partition_yaml_front_matter(input_lines)
+      input_lines = read_utf8(input_file)
+      partitioned = partition_yaml_front_matter(input_lines)
       if (!is.null(partitioned$front_matter)) {
-        output_lines = c(partitioned$front_matter, "", rmarkdown:::read_utf8(output_file))
+        output_lines = c(partitioned$front_matter, "", read_utf8(output_file))
         output_lines = replace_hugo_snippets(output_lines)
         output_lines = add_base_url(output_lines)
         check_alt(output_lines)
-        rmarkdown:::write_utf8(output_lines, output_file)
+        write_utf8(output_lines, output_file)
       }
       output_file
     }

--- a/R/rmarkdown.R
+++ b/R/rmarkdown.R
@@ -1,0 +1,64 @@
+# definitions for the unexported rmarkdown functions used within the package
+# definitions match rmarkdown (2.13)
+
+# see rmarkdown:::partition_yaml_front_matter
+partition_yaml_front_matter = function(input_lines) {
+  validate_front_matter <- function(delimiters) {
+    if (
+      length(delimiters) >= 2 &&
+      (delimiters[2] - delimiters[1] > 1) &&
+      grepl("^---\\s*$", input_lines[delimiters[1]])
+    ) {
+      if (delimiters[1] == 1) {
+        TRUE
+      }
+      else {
+        all(grepl(
+          "^\\s*(<!-- rnb-\\w*-(begin|end) -->)?\\s*$",
+          input_lines[1:delimiters[1] - 1]
+        ))
+      }
+    }
+    else {
+      FALSE
+    }
+  }
+  delimiters <- grep("^(---|\\.\\.\\.)\\s*$", input_lines)
+  if (validate_front_matter(delimiters)) {
+    front_matter <- input_lines[(delimiters[1]):(delimiters[2])]
+    input_body <- c()
+    if (delimiters[1] > 1) {
+      input_body <- c(
+        input_body,
+        input_lines[1:delimiters[1] - 1]
+      )
+    }
+
+    if (delimiters[2] < length(input_lines)) {
+      input_body <- c(input_body, input_lines[-(1:delimiters[2])])
+    }
+    list(front_matter = front_matter, body = input_body)
+  }
+  else {
+    list(front_matter = NULL, body = input_lines)
+  }
+}
+
+# see rmarkdown:::read_utf8
+read_utf8 = function(file) {
+  if (inherits(file, "connection")) {
+    con <- file
+  }
+  else {
+    con <- base::file(file, encoding = "UTF-8")
+    on.exit(close(con), add = TRUE)
+  }
+  enc2utf8(readLines(con, warn = FALSE))
+}
+
+# see rmarkdown:::write_utf8
+write_utf8 = function(text, con, ...) {
+  opts <- options(encoding = "native.enc")
+  on.exit(options(opts), add = TRUE)
+  writeLines(enc2utf8(text), con, ..., useBytes = TRUE)
+}

--- a/man/hugo_md.Rd
+++ b/man/hugo_md.Rd
@@ -30,7 +30,7 @@ hugo_md(
 
 \item{fig_width, fig_height, fig_retina, dev, df_print, includes}{See `?rmarkdown::md_document`}
 
-\item{includes, md_extensions, pandoc_args, ext}{See `?rmarkdown::md_document`}
+\item{md_extensions, pandoc_args, ext}{See `?rmarkdown::md_document`}
 }
 \description{
 This format generates a standard markdown file.

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(hugostyle)
+
+test_check("hugostyle")

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,31 @@
+# Create a minimal rmd to knit using the hugostyle output
+# format. To allow tests to inspect the output rmd
+# example
+# test_that("knitted rmd test", {
+#   src = with_rmd()
+#   out = rmarkdown::render(src)
+#   # read knitted file
+#   lines = readLines(out)
+#   # expectations
+# })
+with_rmd = function(envir = parent.frame()) {
+  # create a temp dir containing a minimal rmd
+  tmp = tempdir()
+  rmddir = file.path(tmp, "rmd")
+  dir.create(rmddir)
+  wd = setwd(rmddir)
+  withr::defer(setwd(wd), envir = envir)
+  withr::defer(unlink(rmddir, recursive = TRUE, force = TRUE), envir = envir)
+  # write minimal Rmd to file
+  target = file.path(rmddir, "test.Rmd")
+  writeLines(c(
+    "---",
+    "output:",
+    "  hugostyle::hugo_md",
+    "---",
+    "",
+    "{{< rstudio-pro-advert >}}"),
+    target
+  )
+  target
+}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,3 @@
+# avoid bug with cli and testthat
+# https://githubhot.com/repo/r-lib/cli/issues/441
+options(cli.hyperlink = FALSE)

--- a/tests/testthat/test-hugo.R
+++ b/tests/testthat/test-hugo.R
@@ -1,0 +1,40 @@
+# this test was introduce as a result of a bug that appears in esaping
+# chars in knitted output resulting from different versions of pandoc
+# original bug was found as a difference between R CLI and RStudio using
+# different versions of pandoc.
+# Pandoc versions:
+#  * 2.5 pass
+#  * 2.11.4 fail
+test_that("knit rmd doesn't escape {{< (system pandoc)", {
+  # set the environment to use the default system wide pandoc install
+  src = with_rmd()
+  oldenv = Sys.getenv("RSTUDIO_PANDOC")
+  Sys.unsetenv("RSTUDIO_PANDOC")
+  withr::defer(Sys.setenv("RSTUDIO_PANDOC" = oldenv))
+  pv = rmarkdown::find_pandoc(cache = FALSE)
+
+  out = rmarkdown::render(src)
+  # read knitted file
+  lines = readLines(out)
+  escaped = stringr::str_detect(lines, "\\&lt")
+  expect_equal(sum(escaped), 0)
+})
+
+test_that("knit rmd doesn't escape {{< (rstudio pandoc)", {
+  # only run test if the rstudio pandoc location is available
+  rstudio_pandoc_dir = "/usr/lib/rstudio/bin/pandoc"
+  skip_if_not(dir.exists(rstudio_pandoc_dir))
+
+  # set environment to render rmd using the rstudio bundled pandoc
+  src = with_rmd()
+  oldenv = Sys.getenv("RSTUDIO_PANDOC")
+  Sys.setenv("RSTUDIO_PANDOC" = rstudio_pandoc_dir)
+  withr::defer(Sys.setenv("RSTUDIO_PANDOC" = oldenv))
+  pv = rmarkdown::find_pandoc(cache = FALSE)
+
+  out = rmarkdown::render(src)
+  # read knitted file
+  lines = readLines(out)
+  escaped = stringr::str_detect(lines, "\\&lt")
+  expect_equal(sum(escaped), 0)
+})


### PR DESCRIPTION
On my machine one of these tests fails, the one that uses the RStudio bundled pandoc version

Test helper to set up minimal rmd to knit with output `hugostyle::hugo_md`, test setup to circumvent bug between {cli} and {testthat} (see https://githubhot.com/repo/r-lib/cli/issues/441)

pandoc location in RStudio is set by the env var `RSTUDIO_PANDOC` which is automatically set in an RStudio session.

Two tests added, one using the pandoc location not set by RStudio, one with it set to the location that this lives on my machine. I suspect that location over operating system may well vary but don't currently know how to account for that.